### PR TITLE
Update utils.py, closes #10

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -690,7 +690,7 @@ def fill_diag(rsm:np.ndarray) -> np.ndarray:
     rsm[np.eye(len(rsm)) == 1.] = 1
     return rsm
 
-@njit(parallel=True, fastmath=True)
+@njit(parallel=False, fastmath=False)
 def matmul(A:np.ndarray, B:np.ndarray) -> np.ndarray:
     I, K = A.shape
     K, J = B.shape
@@ -701,7 +701,7 @@ def matmul(A:np.ndarray, B:np.ndarray) -> np.ndarray:
                 C[i, j] += A[i, k] * B[k, j]
     return C
 
-@njit(parallel=True, fastmath=True)
+@njit(parallel=False, fastmath=False)
 def rsm_pred(W:np.ndarray) -> np.ndarray:
     """convert weight matrix corresponding to the mean of each dim distribution for an object into a RSM"""
     N = W.shape[0]
@@ -715,6 +715,8 @@ def rsm_pred(W:np.ndarray) -> np.ndarray:
                     rsm[i, j] += S_e[i, j] / (S_e[i, j] + S_e[i, k] + S_e[j, k])
     rsm /= N - 2
     rsm += rsm.T #make similarity matrix symmetric
+    rsm = fill_diag(rsm)
+    rsm[rsm > 1] = 1
     return rsm
 
 def rsm(W:np.ndarray, metric:str) -> np.ndarray:
@@ -725,8 +727,8 @@ def compute_trils(W_mod1:np.ndarray, W_mod2:np.ndarray, metric:str) -> float:
     metrics = ['cos', 'pred', 'rho']
     assert metric in metrics, f'\nMetric must be one of {metrics}.\n'
     if metric == 'pred':
-        rsm_1 = fill_diag(rsm_pred(W_mod1))
-        rsm_2 = fill_diag(rsm_pred(W_mod2))
+        rsm_1 = rsm_pred(W_mod1)
+        rsm_2 = rsm_pred(W_mod2)
     else:
         rsm_1 = rsm(W_mod1, metric) #RSM wrt first modality (e.g., DNN)
         rsm_2 = rsm(W_mod2, metric) #RSM wrt second modality (e.g., behavior)


### PR DESCRIPTION
Changed:
1. In the func `rsm_pred`: added a call of `fill_diag` to make the resulting RSM have 1 in its main diagonal.
2. Therefore, removed calls to `fill_diag` in the func `compute_trils`.
3. In the func `rsm_pred`: added setting all elements in `rsm` that are bigger than 1 to 1.
4. Set the njit parameters `parallel` and `fastmath` to `False` for the funcs `matmul` and `rsm_pred`.

NOT changed:
The func `fill_diag` is still part of `__all__`.