### PR TITLE
Update utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -41,7 +41,7 @@ __all__ = [
             'rsm_pred',
             'save_weights_',
             'sparsity',
-            'spose_rsm',
+            'spose2rsm_odd_one_out',
             'avg_sparsity',
             'softmax',
             'sort_weights',

--- a/utils.py
+++ b/utils.py
@@ -712,9 +712,10 @@ def rsm_pred(W: np.ndarray) -> np.ndarray:
     np.fill_diagonal(rsm, 1)
     return rsm
 
-def spose_rsm(W: np.ndarray) -> np.ndarray:
+def spose2rsm_odd_one_out(W: np.ndarray) -> np.ndarray:
     rsm = rsm_pred(W)
     rsm[rsm > 1] = 1
+    assert np.allclose(rsm, rsm.T), '\nRSM is required to be a symmetric matrix\n'
     return rsm
 
 def rsm(W:np.ndarray, metric:str) -> np.ndarray:


### PR DESCRIPTION
Ok so I shot myself a bit in the foot earlier. :)

The assert-part of `fill_diag` is not supported by numba. Hence, my calling `fill_diag` in `rsm_pred` threw errors. This is salvageable by what I PR here:

1. The assert statement in `fill_diag` is actually unnecessary as any matrix B = A + A.T is symmetric (if you don't believe _me_ see [here](https://math.stackexchange.com/questions/506424/how-to-prove-a-at-symmetric-a-at-skew-symmetric)), which is what happens in `rsm_pred` anyway. 
2. There is a boilerplate numpy function for filling diagonals (`np.fill_diagonal`) which is supported by numba, so no need to use the old custom version anymore. :) I therefore completely deprecated `fill_diag` and moved the filling-the-diagonal part into `rsm_pred`.

Further, ">" seems to not be supported by numba, at least not in the simple way I wanted to use it to replace values bigger than 1 with 1 (anyway it threw some error at me, too). Therefore:

3. I defined a new wrapper function `spose_rsm` that does the replacement outside of numba. This is now the function that one should call if one wants to compute a SPoSE RSM based on an embedding.
4. Therefore, in the func `compute_trils`, I replaced the calls to `rsm_pred` with calls to `spose_rsm` in the func.

5. I checked all other modules of this repo and nowhere else had the (now deprecated) func `fill_diag` or the func `rsm_pred` been used.
6. From this module's` __all__`, I removed the (now deprecated) func `fill_diag` and added the new func `spose_rsm`.

Thanks a lot @andropar for explaining the basics of `numba` to me! :)

@martinhebart 